### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Space Shooter
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/spaceShooter)](https://repl.it/github/UzayAnil/spaceShooter)
 The classic retro game recreated using `Pygame` and `python`.
 
 <a href="https://news.ycombinator.com/item?id=10925168"><img src="https://raw.githubusercontent.com/wingify/across-tabs/master/images/hn.png" width="150" height="20"/></a>


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@UzayAnil/spaceShooter).